### PR TITLE
Create generic EntityMapper interface to eliminate code duplication

### DIFF
--- a/app/src/main/java/com/example/talktobook/data/mapper/ChapterMapper.kt
+++ b/app/src/main/java/com/example/talktobook/data/mapper/ChapterMapper.kt
@@ -3,9 +3,9 @@ package com.example.talktobook.data.mapper
 import com.example.talktobook.data.local.entity.ChapterEntity
 import com.example.talktobook.domain.model.Chapter
 
-object ChapterMapper {
+object ChapterMapper : EntityMapper<ChapterEntity, Chapter> {
     
-    fun ChapterEntity.toDomainModel(): Chapter {
+    override fun ChapterEntity.toDomainModel(): Chapter {
         return Chapter(
             id = id,
             documentId = documentId,
@@ -17,7 +17,7 @@ object ChapterMapper {
         )
     }
     
-    fun Chapter.toEntity(): ChapterEntity {
+    override fun Chapter.toEntity(): ChapterEntity {
         return ChapterEntity(
             id = id,
             documentId = documentId,
@@ -27,13 +27,5 @@ object ChapterMapper {
             createdAt = createdAt,
             updatedAt = updatedAt
         )
-    }
-    
-    fun List<ChapterEntity>.toDomainModels(): List<Chapter> {
-        return map { it.toDomainModel() }
-    }
-    
-    fun List<Chapter>.toEntities(): List<ChapterEntity> {
-        return map { it.toEntity() }
     }
 }

--- a/app/src/main/java/com/example/talktobook/data/mapper/DocumentMapper.kt
+++ b/app/src/main/java/com/example/talktobook/data/mapper/DocumentMapper.kt
@@ -5,7 +5,11 @@ import com.example.talktobook.data.local.entity.DocumentWithChapters
 import com.example.talktobook.data.mapper.ChapterMapper.toDomainModel
 import com.example.talktobook.domain.model.Document
 
-object DocumentMapper {
+object DocumentMapper : EntityMapper<DocumentEntity, Document> {
+    
+    override fun DocumentEntity.toDomainModel(): Document {
+        return toDomainModel(emptyList())
+    }
     
     fun DocumentEntity.toDomainModel(chapters: List<com.example.talktobook.domain.model.Chapter> = emptyList()): Document {
         return Document(
@@ -18,7 +22,7 @@ object DocumentMapper {
         )
     }
     
-    fun Document.toEntity(): DocumentEntity {
+    override fun Document.toEntity(): DocumentEntity {
         return DocumentEntity(
             id = id,
             title = title,
@@ -32,13 +36,5 @@ object DocumentMapper {
         return document.toDomainModel(
             chapters = chapters.map { it.toDomainModel() }
         )
-    }
-    
-    fun List<DocumentEntity>.toDomainModels(): List<Document> {
-        return map { it.toDomainModel() }
-    }
-    
-    fun List<Document>.toEntities(): List<DocumentEntity> {
-        return map { it.toEntity() }
     }
 }

--- a/app/src/main/java/com/example/talktobook/data/mapper/EntityMapper.kt
+++ b/app/src/main/java/com/example/talktobook/data/mapper/EntityMapper.kt
@@ -1,0 +1,12 @@
+package com.example.talktobook.data.mapper
+
+interface EntityMapper<Entity, Domain> {
+    
+    fun Entity.toDomainModel(): Domain
+    
+    fun Domain.toEntity(): Entity
+    
+    fun List<Entity>.toDomainModels(): List<Domain> = map { it.toDomainModel() }
+    
+    fun List<Domain>.toEntities(): List<Entity> = map { it.toEntity() }
+}

--- a/app/src/main/java/com/example/talktobook/data/mapper/RecordingMapper.kt
+++ b/app/src/main/java/com/example/talktobook/data/mapper/RecordingMapper.kt
@@ -3,9 +3,9 @@ package com.example.talktobook.data.mapper
 import com.example.talktobook.data.local.entity.RecordingEntity
 import com.example.talktobook.domain.model.Recording
 
-object RecordingMapper {
+object RecordingMapper : EntityMapper<RecordingEntity, Recording> {
     
-    fun RecordingEntity.toDomainModel(): Recording {
+    override fun RecordingEntity.toDomainModel(): Recording {
         return Recording(
             id = id,
             timestamp = timestamp,
@@ -17,7 +17,7 @@ object RecordingMapper {
         )
     }
     
-    fun Recording.toEntity(): RecordingEntity {
+    override fun Recording.toEntity(): RecordingEntity {
         return RecordingEntity(
             id = id,
             timestamp = timestamp,
@@ -27,13 +27,5 @@ object RecordingMapper {
             duration = duration,
             title = title
         )
-    }
-    
-    fun List<RecordingEntity>.toDomainModels(): List<Recording> {
-        return map { it.toDomainModel() }
-    }
-    
-    fun List<Recording>.toEntities(): List<RecordingEntity> {
-        return map { it.toEntity() }
     }
 }

--- a/app/src/test/java/com/example/talktobook/data/mapper/EntityMapperTest.kt
+++ b/app/src/test/java/com/example/talktobook/data/mapper/EntityMapperTest.kt
@@ -1,0 +1,117 @@
+package com.example.talktobook.data.mapper
+
+import com.example.talktobook.data.local.entity.RecordingEntity
+import com.example.talktobook.domain.model.Recording
+import org.junit.Test
+import org.junit.Assert.*
+
+class EntityMapperTest {
+
+    private object TestMapper : EntityMapper<RecordingEntity, Recording> {
+        override fun RecordingEntity.toDomainModel(): Recording {
+            return Recording(
+                id = id,
+                timestamp = timestamp,
+                audioFilePath = audioFilePath,
+                transcribedText = transcribedText,
+                status = status,
+                duration = duration,
+                title = title
+            )
+        }
+
+        override fun Recording.toEntity(): RecordingEntity {
+            return RecordingEntity(
+                id = id,
+                timestamp = timestamp,
+                audioFilePath = audioFilePath,
+                transcribedText = transcribedText,
+                status = status,
+                duration = duration,
+                title = title
+            )
+        }
+    }
+
+    @Test
+    fun `toDomainModels should map list of entities to domain models`() {
+        val entities = listOf(
+            RecordingEntity(
+                id = 1L,
+                timestamp = 123456789L,
+                audioFilePath = "/path/to/audio",
+                transcribedText = "Test text",
+                status = "COMPLETED",
+                duration = 5000L,
+                title = "Test Recording"
+            ),
+            RecordingEntity(
+                id = 2L,
+                timestamp = 987654321L,
+                audioFilePath = "/path/to/audio2",
+                transcribedText = "Test text 2",
+                status = "PENDING",
+                duration = 3000L,
+                title = "Test Recording 2"
+            )
+        )
+
+        val result = with(TestMapper) { entities.toDomainModels() }
+
+        assertEquals(2, result.size)
+        assertEquals(1L, result[0].id)
+        assertEquals("Test text", result[0].transcribedText)
+        assertEquals(2L, result[1].id)
+        assertEquals("Test text 2", result[1].transcribedText)
+    }
+
+    @Test
+    fun `toEntities should map list of domain models to entities`() {
+        val domainModels = listOf(
+            Recording(
+                id = 1L,
+                timestamp = 123456789L,
+                audioFilePath = "/path/to/audio",
+                transcribedText = "Test text",
+                status = "COMPLETED",
+                duration = 5000L,
+                title = "Test Recording"
+            ),
+            Recording(
+                id = 2L,
+                timestamp = 987654321L,
+                audioFilePath = "/path/to/audio2",
+                transcribedText = "Test text 2",
+                status = "PENDING",
+                duration = 3000L,
+                title = "Test Recording 2"
+            )
+        )
+
+        val result = with(TestMapper) { domainModels.toEntities() }
+
+        assertEquals(2, result.size)
+        assertEquals(1L, result[0].id)
+        assertEquals("Test text", result[0].transcribedText)
+        assertEquals(2L, result[1].id)
+        assertEquals("Test text 2", result[1].transcribedText)
+    }
+
+    @Test
+    fun `empty list should return empty list for toDomainModels`() {
+        val emptyEntities = emptyList<RecordingEntity>()
+        
+        val result = with(TestMapper) { emptyEntities.toDomainModels() }
+        
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `empty list should return empty list for toEntities`() {
+        val emptyDomainModels = emptyList<Recording>()
+        
+        val result = with(TestMapper) { emptyDomainModels.toEntities() }
+        
+        assertTrue(result.isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary
- Created generic EntityMapper interface to eliminate code duplication across data mappers
- Refactored RecordingMapper, DocumentMapper, and ChapterMapper to implement the interface
- Added comprehensive unit tests for the EntityMapper interface
- Removed duplicate list conversion methods while preserving all existing functionality

## Changes Made
- **EntityMapper.kt**: New generic interface with type parameters for Entity and Domain
- **RecordingMapper.kt**: Implements EntityMapper<RecordingEntity, Recording>
- **DocumentMapper.kt**: Implements EntityMapper<DocumentEntity, Document> (preserves DocumentWithChapters functionality)
- **ChapterMapper.kt**: Implements EntityMapper<ChapterEntity, Chapter>
- **EntityMapperTest.kt**: Comprehensive unit tests covering all interface methods

## Test Plan
- [x] Unit tests for EntityMapper interface covering list conversions
- [x] Verified all existing mapper functionality is preserved
- [x] Tested empty list handling
- [x] Confirmed type safety with generic constraints

🤖 Generated with [Claude Code](https://claude.ai/code)